### PR TITLE
Initial restructure (#16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Stop config files being commited
 *-Config.xml
+*Credentials.xml
 
 # Stop editor backup files being commited
 *.bak


### PR DESCRIPTION
* Initial push of new DB schema backups

* Add .gitignore

* Fix .gitignore and exlude editor backups too

* Finalized restructuring

* Rework New-BackupPath function to return the absolute path, then use that as target - not implict current directory

* Clarify message if BackupRoot is not git repo

* robocopy: reduce excessive default retries and don't print progress of each file copy

* Fix export of events from DB

* add git gc to speed up commits

* export CWA Script wrapper

* Exclude DB Credentials from being commited

* Ensure all directories are created silently

* Read location of LTShare for registry if found

* Add script name to warning about missing folder

* Fix export of SQL items with - in the name

* Change robocopy name and use defined logs path

* clean up CWA scripts commits

* Fix link to Scripts ToC.md in output git repo

* DB Schema regex filtering